### PR TITLE
feat: add label "triage:no" to renovate PRs

### DIFF
--- a/.github/renovate/base.json5
+++ b/.github/renovate/base.json5
@@ -6,7 +6,7 @@
     ":semanticCommitScopeDisabled",
   ],
   ignorePresets: [":semanticPrefixFixDepsChoreOthers"],
-  labels: ["dependencies"],
+  labels: ["dependencies", "triage:no"],
 
   // Wait well over npm's three day window for any new package as a precaution against malicious publishes
   // https://docs.npmjs.com/policies/unpublish/#packages-published-less-than-72-hours-ago


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

this PR adds "triage: no" to renovate PRs, to avoid it being added to the project triage.

#### What changes did you make? (Give an overview)

#### Related Issues

fixes https://github.com/eslint/workflows/issues/23
<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
