### PR TITLE
fix: add `--if-present` to Bun CI

### DIFF
--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Bun install, build, and test
               run: |
                   bun install
-                  bun run --bun build --if-present
-                  bun run --bun test --if-present
+                  bun run --if-present --bun build
+                  bun run --if-present --bun test
               env:
                   CI: true


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've added the `--if-present` flag to the Bun CI to handle cases where the `build` or `test` script is missing.

In some cases, such as in `create-config` repository, the `build` or `test` scripts may be missing. When they are, Bun throws an error, so I added the `--if-present` flag.

---

Reference: https://bun.com/docs/cli/run#resolution-order

<img width="751" height="334" alt="image" src="https://github.com/user-attachments/assets/50877c20-8922-4345-8a16-675314891503" />

---

`create-config` Bun CI failure example:

https://github.com/eslint/create-config/actions/runs/18614674241/job/53077559021?pr=210

<img width="1490" height="492" alt="image" src="https://github.com/user-attachments/assets/3931ec34-12ff-4949-a85d-188d1b937e70" />

## What changes did you make? (Give an overview)

In this PR, I've added the `--if-present` flag to the Bun CI to handle cases where the `build` or `test` script is missing.

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

I've confirmed this new workflow works fine in the `markdown` and `rewrite` repositories — it's working as expected. Sorry for the duplicate review.