### PR TITLE
feat: update deps version in package.json explicitly

### DIFF
--- a/.github/renovate/base.json5
+++ b/.github/renovate/base.json5
@@ -7,7 +7,6 @@
   ],
   ignorePresets: [":semanticPrefixFixDepsChoreOthers"],
   labels: ["dependencies", "triage:no"],
-  rangeStrategy: "bump",
 
   // Wait well over npm's three day window for any new package as a precaution against malicious publishes
   // https://docs.npmjs.com/policies/unpublish/#packages-published-less-than-72-hours-ago

--- a/.github/renovate/eslint-app.json5
+++ b/.github/renovate/eslint-app.json5
@@ -1,0 +1,5 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>eslint/workflows//.github/renovate/eslint-base.json5"],
+  rangeStrategy: "bump",
+}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

The current `rangeStrategy` config options for renovate is set to `auto`.

This means:

> Finally, if the update is in-range, Renovate will update the lockfile with the new exact version. 
> https://docs.renovatebot.com/configuration-options/#rangestrategy

In-range update only update the lock and do not reflect in package.json.

Since updates are automatically handled by renovate, it may be preferable to reflect lock changes in package.json.

#### What changes did you make? (Give an overview)

Change the `rangeStrategy` config option for renovate from the default `auto` to `bump`.

#### Related Issues

Report on https://github.com/eslint/code-explorer/pull/197#issuecomment-3417169562

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
