### PR TITLE
fix: Remove ignorePresets from Renovate configuration

### DIFF
--- a/.github/renovate/base.json5
+++ b/.github/renovate/base.json5
@@ -5,7 +5,6 @@
     ":approveMajorUpdates",
     ":semanticCommitScopeDisabled",
   ],
-  ignorePresets: [":semanticPrefixFixDepsChoreOthers"],
   labels: ["dependencies", "triage:no"],
 
   // Wait well over npm's three day window for any new package as a precaution against malicious publishes


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x ] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This change removes the custom semantic prefix preset to align with release-please's expected commit conventions:
- dependencies updates now use "fix:" prefix
- devDependencies updates now use "chore:" prefix

The removal enables better integration with release-please by using standard semantic commit prefixes that release-please recognizes for automatic version bumping and changelog generation.

Especially after the @eslint/* update, using "fix", release-please can update the version (whereas using "chore" cannot).

#### What changes did you make? (Give an overview)

#### Related Issues

refs:https://github.com/eslint/markdown/issues/577#issuecomment-3484856458
<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
