### PR TITLE
fix: exclude Node.js and npm update from `eslint-app.json5`

### DIFF
--- a/.github/renovate/eslint-app.json5
+++ b/.github/renovate/eslint-app.json5
@@ -2,5 +2,5 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>eslint/workflows//.github/renovate/eslint-base.json5"],
   rangeStrategy: "bump",
-  ignoreDeps: ["eslint", "eslint-config-base"],
+  ignoreDeps: ["node", "npm"],
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've excluded Node.js and npm updates from `eslint-app.json5`.

I added the `ignoreDeps: ["node", "npm"]` option to skip `node` and `npm` updates and verified the behavior in my fork: https://github.com/lumirlumir/fork-code-explorer

- Before adding the `ignoreDeps` option: a `node` update appeared in the update list.

<img width="762" height="601" alt="스크린샷 2025-11-05 225025" src="https://github.com/user-attachments/assets/07662059-6e07-4603-87da-34a017a78b34" />

- After adding the `ignoreDeps` option: no `node` updates appear in the update list (except for `@types/node`).

<img width="759" height="569" alt="스크린샷 2025-11-05 225239" src="https://github.com/user-attachments/assets/8c790542-e5ae-43c7-92f7-cd259709003e" />

## What changes did you make? (Give an overview)

In this PR, I've excluded Node.js and npm updates from `eslint-app.json5`.

## Related Issues

Fixes: #31

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

FYI, the link for the `ignoreDeps` option:

https://docs.renovatebot.com/configuration-options/#ignoredeps

<img width="367" height="512" alt="image" src="https://github.com/user-attachments/assets/bad93113-fd45-4889-be2e-2acc73a93b43" />

