### PR TITLE
feat: ignore "blocked" label for stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,5 +31,5 @@ jobs:
                   stale-pr-message: "Hi everyone, it looks like we lost track of this pull request. Please review and see what the next steps are. This pull request will auto-close in 7 days without an update."
                   close-pr-message: "This pull request was auto-closed due to inactivity. While we wish we could keep working on every request, we unfortunately don't have the bandwidth to continue here and need to focus on other things. You can resubmit this pull request if you would like to continue working on it."
                   exempt-all-assignees: true
-                  exempt-issue-labels: accepted
-                  exempt-pr-labels: accepted
+                  exempt-issue-labels: accepted,blocked
+                  exempt-pr-labels: accepted,blocked


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
Ignore issues and PRs labelled with `blocked` for the stale bot.

#### What changes did you make? (Give an overview)
Add the label `blocked` to `exempt-issue-labels` and `exempt-pr-labels` for the stale bot which is [a single string and not an array](https://github.com/actions/stale#exempt-issue-labels).

#### Related Issues
Fixes #35.

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
No