### PR TITLE
fix: group non-major dev-dependencies correctly

### DIFF
--- a/.github/renovate/eslint-base.json5
+++ b/.github/renovate/eslint-base.json5
@@ -3,25 +3,24 @@
   extends: ["github>eslint/workflows//.github/renovate/base.json5"],
   packageRules: [
     {
+      description: "Update non-major dev-dependencies together.",
+      groupName: "non-major dev-dependencies",
+      groupSlug: "non-major-dev-deps"
+      matchDepTypes: ["devDependencies"],
+      matchUpdateTypes: ["minor", "patch"],
+    },
+    {
       description: "Update ESLint packages together.",
       groupName: "eslint",
-      matchPackagePrefixes: ["@eslint/"],
-      matchPackageNames: ["espree", "eslint-scope", "eslint-visitor-keys"],
+      matchPackageNames: ["@eslint/**", "espree", "eslint-scope", "eslint-visitor-keys"],
       minimumReleaseAge: null, // Don't wait for these packages
       rangeStrategy: "bump",
     },
     {
-      description: "Update ESLint dev dependencies together.",
+      description: "Update ESLint dev-dependencies together.",
       groupName: "eslint-dev",
       matchPackageNames: ["eslint", "eslint-config-eslint"],
       minimumReleaseAge: null, // Don't wait for these packages
-    },
-    {
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": ["^@eslint/", "eslint", "eslint-config-eslint", "espree", "eslint-scope", "eslint-visitor-keys"],
-      "groupName": "non-major devDependencies",
-      "groupSlug": "non-major-dev-deps"
     },
   ],
 }

--- a/.github/renovate/eslint-base.json5
+++ b/.github/renovate/eslint-base.json5
@@ -5,7 +5,7 @@
     {
       description: "Update non-major dev-dependencies together.",
       groupName: "non-major dev-dependencies",
-      groupSlug: "non-major-dev-deps"
+      groupSlug: "non-major-dev-deps",
       matchDepTypes: ["devDependencies"],
       matchUpdateTypes: ["minor", "patch"],
     },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've resolved the issue mentioned in #30.

Currently, the non-major dev-dependencies are not grouped correctly, which resulted in incorrect grouping, especially in the `code-explorer` repository.

I've tested this new configuration in my fork of the `code-explorer` repository, and it appears to work correctly, as described in the next section.

Repository: https://github.com/lumirlumir/fork-code-explorer/issues/3

## What changes did you make? (Give an overview)

It seems the configuration was applied incorrectly because of the order of the `packageRules`. The `non-major dev-dependencies` group should have been at the top level so that ESLint-specific rules could override it, but it wasn’t, so the `non-major dev-dependencies` group unintentionally overrode the ESLint-related group in an unpredictable way, which I think caused the issue.

After this change, the Renovate configuration is working as expected.

### Before

The version bump PRs for `vite`, `typescript-eslint`, and `eslint-plugin-react-hooks` were created separately, even though they are listed as dev dependencies:

https://github.com/eslint/code-explorer/issues/138

<img width="833" height="39" alt="image" src="https://github.com/user-attachments/assets/793e39d0-c9e0-4ae8-8b15-f49810fa0ae1" />

<img width="857" height="38" alt="image" src="https://github.com/user-attachments/assets/7b9f7a25-ebde-4848-8d77-107acc876a98" />

<img width="838" height="36" alt="image" src="https://github.com/user-attachments/assets/04b14821-3fb0-4e4e-bfad-64d1056da8ba" />

### After

The version-bump PRs for `vite`, `typescript-eslint`, and `eslint-plugin-react-hooks` have been consolidated.

https://github.com/lumirlumir/fork-code-explorer/issues/3

<img width="844" height="31" alt="image" src="https://github.com/user-attachments/assets/83b28b0a-f3a0-4dd8-b910-fb6a2adea649" />

## Related Issues

Fixes: #30

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A
