### PR TITLE
feat: Add helper to pin GitHub Action digests

### DIFF
--- a/.github/renovate/base.json5
+++ b/.github/renovate/base.json5
@@ -4,7 +4,6 @@
     "config:recommended",
     ":approveMajorUpdates",
     ":semanticCommitScopeDisabled",
-    "helpers:pinGitHubActionDigests",
   ],
   ignorePresets: [":semanticPrefixFixDepsChoreOthers"],
   labels: ["dependencies", "triage:no"],
@@ -18,6 +17,13 @@
       description: "Use the deps:actions label for github-action manager updates (this means Renovate's github-action manager).",
       addLabels: ["deps:actions"],
       matchManagers: ["github-actions"],
+    },
+    {
+      description: "Pin 3rd-party actions",
+      extends: ["helpers:pinGitHubActionDigests"],
+      addLabels: ["deps:actions"],
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["!actions/**"]
     },
     {
       description: "Use the deps:npm label for npm manager packages (this means Renovate's npm manager).",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [ x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This pull request makes a minor update to the Renovate configuration by adding a helper to pin GitHub Action digests, which improves security and reliability for automated dependency updates.

* Renovate configuration: Added the `helpers:pinGitHubActionDigests` preset to ensure that GitHub Actions are referenced by their specific digest, reducing the risk of supply chain attacks. (.github/renovate/base.json5)


#### What changes did you make? (Give an overview)

refs: https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver

#### Related Issues

https://github.com/eslint/eslint/pull/20310
<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
