### PR TITLE
fix: update matchPackageNames to exclude 'github' actions

### DIFF
--- a/.github/renovate/base.json5
+++ b/.github/renovate/base.json5
@@ -22,7 +22,7 @@
       extends: ["helpers:pinGitHubActionDigests"],
       addLabels: ["deps:actions"],
       matchManagers: ["github-actions"],
-      matchPackageNames: ["!(actions|github)/**"]
+      matchPackageNames: ["!actions/**", "!github/**"],
     },
     {
       description: "Use the deps:npm label for npm manager packages (this means Renovate's npm manager).",


### PR DESCRIPTION
refs: https://github.com/eslint/eslint/pull/20397#discussion_r2618581428
This pull request makes a small update to the Renovate configuration for GitHub Actions dependencies. The change expands the exclusion pattern in the `matchPackageNames` field to also exclude `github/**` packages, not just `actions/**`. 

* [`.github/renovate/base.json5`](diffhunk://#diff-f5e55a6b938bef74ff0559c4722688aa17782f66e3c334de1463d649c67359afL25-R25): Updated the `matchPackageNames` pattern to exclude both `actions/**` and `github/**` when applying the `deps:actions` label for GitHub Actions dependencies.
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
