### PR TITLE
feat: auto merge dev-dependencies

### DIFF
--- a/.github/renovate/base.json5
+++ b/.github/renovate/base.json5
@@ -32,7 +32,7 @@
     {
       description: "Pin prettier",
       matchPackageNames: ["prettier"],
-      rangeStrategy: "pin",
+      rangeStrategy: "pin", // TODO
     },
   ],
 }

--- a/.github/renovate/base.json5
+++ b/.github/renovate/base.json5
@@ -16,7 +16,6 @@
       description: "Use the deps:actions label for github-action manager updates (this means Renovate's github-action manager).",
       addLabels: ["deps:actions"],
       matchManagers: ["github-actions"],
-      automerge: true,
     },
     {
       description: "Pin 3rd-party actions",
@@ -24,7 +23,6 @@
       addLabels: ["deps:actions"],
       matchManagers: ["github-actions"],
       matchPackageNames: ["!actions/**", "!github/**"],
-      automerge: true,
     },
     {
       description: "Use the deps:npm label for npm manager packages (this means Renovate's npm manager).",

--- a/.github/renovate/base.json5
+++ b/.github/renovate/base.json5
@@ -16,6 +16,7 @@
       description: "Use the deps:actions label for github-action manager updates (this means Renovate's github-action manager).",
       addLabels: ["deps:actions"],
       matchManagers: ["github-actions"],
+      automerge: true,
     },
     {
       description: "Pin 3rd-party actions",
@@ -23,6 +24,7 @@
       addLabels: ["deps:actions"],
       matchManagers: ["github-actions"],
       matchPackageNames: ["!actions/**", "!github/**"],
+      automerge: true,
     },
     {
       description: "Use the deps:npm label for npm manager packages (this means Renovate's npm manager).",
@@ -32,7 +34,8 @@
     {
       description: "Pin prettier",
       matchPackageNames: ["prettier"],
-      rangeStrategy: "pin", // TODO
+      rangeStrategy: "pin",
+      automerge: true,
     },
   ],
 }

--- a/.github/renovate/eslint-base.json5
+++ b/.github/renovate/eslint-base.json5
@@ -8,6 +8,7 @@
       groupSlug: "non-major-dev-deps",
       matchDepTypes: ["devDependencies"],
       matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
     },
     {
       description: "Update ESLint packages together.",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've enabled auto-merge for dev-dependencies and GitHub Actions, as mentioned in https://github.com/eslint/workflows/issues/48.

I could set the automerge option at the global scope and disable it elsewhere (the current setup disables automerge globally and enables it where necessary), but, I intentionally enabled auto-merge in a narrow, separate scope to prevent unwanted side effects, since this is the first introduction of auto-merge and a global setting could cause unwanted side-effects.

I've tested some of the setups in my forked repository by following the [guide](https://docs.renovatebot.com/key-concepts/automerge), and everything works as expected. The detailed test results can be found in the comments below.

## What changes did you make? (Give an overview)

In this PR, I've enabled auto-merge for dev-dependencies and GitHub Actions, as mentioned in https://github.com/eslint/workflows/issues/48.

## Related Issues

Closes: #48

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

Unlike other workflow setups, **auto-merge requires two setups** per repository, as mentioned in the Renovate documentation:

### 1. Turn on "Allow auto-merge" in GitHub settings:

First, we need to enable "Allow auto-merge" in the GitHub settings to make auto-merge work.

From testing in my forked repository, I found that if this isn't enabled, auto-merge won't run.

<img width="790" height="123" alt="image" src="https://github.com/user-attachments/assets/15b05857-ebaf-44e4-bb06-630c92781f4a" />

Also, the Renovate docs include a description of this:

<img width="746" height="76" alt="image" src="https://github.com/user-attachments/assets/373066ce-661a-4d08-a9f4-f7db3d7cb0db" />

### 2. Turn on "Require status checks to pass":

Secondly, we need to mark the CI checks we want as "required" so they must pass. As the Renovate documentation notes, if these aren't set, CI checks that aren't required may be ignored, and PRs could be merged even if those checks fail.

Ref: https://docs.renovatebot.com/configuration-options/#automerge

<img width="756" height="298" alt="image" src="https://github.com/user-attachments/assets/2be35992-3cc8-41c1-8f67-e0813eebbd1d" />

The branch protection rule below should be enabled and workflows should be marked as "required" in the CI settings.

<img width="765" height="385" alt="image" src="https://github.com/user-attachments/assets/ebc30241-d074-4506-be8a-f903fdf0ebb7" />
