### PR TITLE
fix: accept inputs from the caller workflow to fix pnpm CI failure

### DIFF
--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -11,10 +11,9 @@ name: ci-package-manager
 on:
     workflow_call:
         inputs:
-            pnpm_allow_build:
+            pnpm_config_allow_build:
                 required: false
                 description: The value to use for `--allow-build` when installing with pnpm.
-                default: ''
                 type: string
 
 jobs:
@@ -133,23 +132,15 @@ jobs:
               with:
                   node-version: "lts/*"
 
-            - name: pnpm add without allow builds
-              if: ${{ inputs.pnpm_allow_build == '' }}
+            - name: pnpm add
               run: |
                   cat > .npmrc <<EOT
                   auto-install-peers=true
                   node-linker=hoisted
                   EOT
                   pnpm add ./*.tgz -D
-
-            - name: pnpm add with allow builds
-              if: ${{ inputs.pnpm_allow_build != '' }}
-              run: |
-                  cat > .npmrc <<EOT
-                  auto-install-peers=true
-                  node-linker=hoisted
-                  EOT
-                  pnpm add --allow-build=${{ inputs.pnpm_allow_build }} ./*.tgz -D
+              env:
+                  PNPM_CONFIG_ALLOW_BUILD: ${{ inputs.pnpm_config_allow_build }}
 
     bun-install:
         needs: build-tarball

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -11,9 +11,10 @@ name: ci-package-manager
 on:
     workflow_call:
         inputs:
-            pnpm_config_allow_build:
+            pnpm_allow_build_args:
                 required: false
-                description: The value to use for `--allow-build` when installing with pnpm.
+                description: The arguments to use for `--allow-build` when installing with pnpm.
+                default: ''
                 type: string
 
 jobs:
@@ -138,9 +139,9 @@ jobs:
                   auto-install-peers=true
                   node-linker=hoisted
                   EOT
-                  pnpm add ./*.tgz -D
+                  pnpm add ${PNPM_ALLOW_BUILD_ARG} ./*.tgz -D
               env:
-                  PNPM_CONFIG_ALLOW_BUILD: ${{ inputs.pnpm_config_allow_build }}
+                  PNPM_ALLOW_BUILD_ARG: ${{ case(inputs.pnpm_allow_build_args != '', format('--allow-build={0}', inputs.pnpm_allow_build_args), '') }}
 
     bun-install:
         needs: build-tarball

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -133,6 +133,7 @@ jobs:
                   auto-install-peers=true
                   node-linker=hoisted
                   EOT
+                  pnpm approve-builds --all
                   pnpm add ./*.tgz -D
 
     bun-install:

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -139,9 +139,9 @@ jobs:
                   auto-install-peers=true
                   node-linker=hoisted
                   EOT
-                  pnpm add ${PNPM_ALLOW_BUILD_ARG} ./*.tgz -D
+                  pnpm add ${PNPM_ALLOW_BUILD_ARGS} ./*.tgz -D
               env:
-                  PNPM_ALLOW_BUILD_ARG: ${{ case(inputs.pnpm_allow_build_args != '', format('--allow-build={0}', inputs.pnpm_allow_build_args), '') }}
+                  PNPM_ALLOW_BUILD_ARGS: ${{ case(inputs.pnpm_allow_build_args != '', format('--allow-build={0}', inputs.pnpm_allow_build_args), '') }}
 
     bun-install:
         needs: build-tarball

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -10,6 +10,12 @@ name: ci-package-manager
 
 on:
     workflow_call:
+        inputs:
+            pnpm_approve_builds:
+                required: false
+                description: The value to use for `pnpm approve-builds` when installing with pnpm. If not provided, the command will be skipped.
+                default: ''
+                type: string
 
 jobs:
     build-tarball:
@@ -127,13 +133,16 @@ jobs:
               with:
                   node-version: "lts/*"
 
+            - name: pnpm approve-builds
+              if: inputs.pnpm_approve_builds != ''
+              run: pnpm approve-builds ${{ inputs.pnpm_approve_builds }}
+
             - name: pnpm add
               run: |
                   cat > .npmrc <<EOT
                   auto-install-peers=true
                   node-linker=hoisted
                   EOT
-                  pnpm approve-builds --all
                   pnpm add ./*.tgz -D
 
     bun-install:

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -11,9 +11,9 @@ name: ci-package-manager
 on:
     workflow_call:
         inputs:
-            pnpm_approve_builds:
+            pnpm_allow_build:
                 required: false
-                description: The value to use for `pnpm approve-builds` when installing with pnpm. If not provided, the command will be skipped.
+                description: The value to use for `--allow-build` when installing with pnpm.
                 default: ''
                 type: string
 
@@ -133,17 +133,23 @@ jobs:
               with:
                   node-version: "lts/*"
 
-            - name: pnpm approve-builds
-              if: inputs.pnpm_approve_builds != ''
-              run: pnpm approve-builds ${{ inputs.pnpm_approve_builds }}
-
-            - name: pnpm add
+            - name: pnpm add without allow builds
+              if: ${{ inputs.pnpm_allow_build == '' }}
               run: |
                   cat > .npmrc <<EOT
                   auto-install-peers=true
                   node-linker=hoisted
                   EOT
                   pnpm add ./*.tgz -D
+
+            - name: pnpm add with allow builds
+              if: ${{ inputs.pnpm_allow_build != '' }}
+              run: |
+                  cat > .npmrc <<EOT
+                  auto-install-peers=true
+                  node-linker=hoisted
+                  EOT
+                  pnpm add --allow-build=${{ inputs.pnpm_allow_build }} ./*.tgz -D
 
     bun-install:
         needs: build-tarball


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

This PR fixes an issue where CI on the `main` branch of `generator-eslint` is failing: https://github.com/eslint/generator-eslint/actions/runs/26231391017/job/77192617767?pr=270

As of [`pnpm` v11, the `postinstall` build script checks have been enhanced](https://pnpm.io/blog/releases/11.0#security--build-defaults) for security reasons, and the `generator-eslint` package was affected.

<img width="582" height="118" alt="image" src="https://github.com/user-attachments/assets/9e813834-b0e8-4ffe-ab9b-ff63ccc82ea0" />

## What changes did you make? (Give an overview)

This fix requires changes in both the `workflows` and `generator-eslint` repositories.

### `workflows`

I updated the workflow to retrieve the `pnpm_allow_build_args` input from the caller workflow, in this case, `generator-eslint`.

This input is passed to pnpm’s `--allow-build` flag, and the flag is used only when this input is actually provided.

### `generator-eslint`

Ref: https://github.com/eslint/generator-eslint/pull/270/changes

I updated `generator-eslint`’s `ci-package-manager` workflow to pass `yo` to pnpm’s `--allow-build` flag.

This PR needs to be merged after that change lands, since this change needs to be applied on the `main` branch first.

The CI on `generator-eslint` is all passing: https://github.com/eslint/generator-eslint/pull/270

## Related Issues

Ref: https://github.com/eslint/generator-eslint/actions/runs/26088324878/job/76707210206

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A
