### PR TITLE
fix: preapprove ESLint packages for Yarn age gate

### DIFF
--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -102,6 +102,14 @@ jobs:
               run: |
                   corepack use yarn@latest
                   yarn init -p
+                  yarn config set npmPreapprovedPackages --json '[
+                    "@eslint/*",
+                    "eslint",
+                    "eslint-config-eslint",
+                    "eslint-scope",
+                    "eslint-visitor-keys",
+                    "espree"
+                  ]'
                   yarn add ./*.tgz -D
               env:
                   YARN_ENABLE_IMMUTABLE_INSTALLS: 0 # Allow installs to modify lockfile


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Yarn 4.15.0 now enables `npmMinimalAgeGate: 1d` by default, which caused `ci-package-manager / yarn-install` to fail in eslint/css#453 because `@eslint/css-tree@4.0.4` was still within Yarn's age gate:

https://github.com/eslint/css/actions/runs/26190898993/job/77058797132

#### What changes did you make? (Give an overview)

- Configured the Yarn Modern install check to preapprove ESLint-owned packages via `npmPreapprovedPackages`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
