### PR TITLE
ci: add explicit permissions to ci-package-manager

### DIFF
--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -17,6 +17,9 @@ on:
                 default: ''
                 type: string
 
+permissions:
+    contents: read
+
 jobs:
     build-tarball:
         runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
Security hardening: this PR declares a workflow-level `permissions: contents: read` in `ci-package-manager.yml`, which currently inherits the default `GITHUB_TOKEN` permissions from the calling repository.

The main motivation is that the install jobs run lifecycle scripts from many third-party dependencies, so limiting the token to read-only reduces the blast radius if any of them is ever compromised.

#### What changes did you make? (Give an overview)

Added a workflow-level `permissions` block with `contents: read` only.

#### Is there anything you'd like reviewers to focus on?

I went through each job in the workflow to confirm this doesn't change any behavior:

- `actions/checkout` only needs `contents: read`.
- `upload-artifact` / `download-artifact` use the Actions runtime token, not `GITHUB_TOKEN` scopes.
- The install jobs (npm, Yarn v1, Yarn Modern, pnpm, bun) make no GitHub API calls.

Also, since this is a reusable workflow, a called workflow can only downgrade (never elevate) the caller's token — so this effectively caps the `GITHUB_TOKEN` for every repository that calls it.