### PR TITLE
ci: fix `stale` bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,10 +4,12 @@ on:
     schedule:
         - cron: "31 22 * * *" # Runs every day at 10:31 PM UTC
 
+    workflow_dispatch:
+
     workflow_call:
         secrets:
             token:
-                required: true
+                required: false
                 description: GitHub token to use for the workflow
 
 jobs:
@@ -22,7 +24,7 @@ jobs:
             - name: Mark stale issues and pull requests
               uses: actions/stale@v10
               with:
-                  repo-token: ${{ secrets.token }}
+                  repo-token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
                   days-before-issue-stale: 30
                   days-before-pr-stale: 10
                   days-before-close: 7


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes an issue where the `stale` bot wasn’t working in this `workflows` repository.

See: https://github.com/eslint/workflows/actions/workflows/stale.yml

This happened because the `stale.yml` workflow was acting as both a centralized reusable workflow and a dedicated stale bot workflow for this `workflows` repository, so `secrets.token` wasn’t passed as it is in other repositories, which caused the error.

#### What changes did you make? (Give an overview)

Added a fallback to `secrets.GITHUB_TOKEN` and made `secrets.token` optional so the default fallback token is used when a token isn’t supplied.

I also added `workflow_dispatch:` so this workflow can be run manually for testing when it’s changed. This is optional, but it doesn’t hurt and gives us more flexibility, so I think it’s worth adding.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A